### PR TITLE
Update flag to exit on OOM

### DIFF
--- a/presto/etc/jvm.config
+++ b/presto/etc/jvm.config
@@ -6,7 +6,7 @@
 -XX:+CMSClassUnloadingEnabled
 -XX:+AggressiveOpts
 -XX:+HeapDumpOnOutOfMemoryError
--XX:OnOutOfMemoryError=kill -9 %p
+-XX:+ExitOnOutOfMemoryError
 -DHADOOP_USER_NAME=hive
 -Duser.timezone=UTC
 -Xdebug 


### PR DESCRIPTION
`-XX:OnOutOfMemoryError="kill -9 %p"` may somehow fail:

```
java.lang.OutOfMemoryError: Java heap space
Dumping heap to java_pid1.hprof ...
Heap dump file created [524990525 bytes in 1.448 secs]
#
# java.lang.OutOfMemoryError: Java heap space
# -XX:OnOutOfMemoryError="kill -9 %p"
#   Executing /bin/sh -c "kill -9 1"...
ERROR: ld.so: object '/usr/lib/presto/bin/procname/Linux-x86_64/libprocname.so' from LD_PRELOAD cannot be preloaded: ignored.
```

leaving JVM alive, dying...