### PR TITLE
Update JVM args for starburstdata/presto docker image (v3)

### DIFF
--- a/presto/etc/jvm.config
+++ b/presto/etc/jvm.config
@@ -1,8 +1,5 @@
 -server
 -Xmx1G
--XX:+UseG1GC
--XX:+UseGCOverheadLimit
--XX:+ExplicitGCInvokesConcurrent
 -XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M

--- a/presto/etc/jvm.config
+++ b/presto/etc/jvm.config
@@ -1,6 +1,5 @@
 -server
 -Xmx1G
--XX:+HeapDumpOnOutOfMemoryError
 -XX:+ExitOnOutOfMemoryError
 -XX:ReservedCodeCacheSize=150M
 -DHADOOP_USER_NAME=hive


### PR DESCRIPTION
Itemized changes:

* Remove flags related to G1GC -- G1 doesn't make sense for such a small
  heap

* Remove `-XX:+HeapDumpOnOutOfMemoryError` -- while this is cool flag to
  have, it's not that useful in a docker container
