### PR TITLE
Decouple artifact download from Presto Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 presto/installdir/presto-cli-*-executable.jar
 presto/installdir/presto-server-rpm-*.x86_64.rpm
 .DS_Store
+*.swp

--- a/presto/Dockerfile
+++ b/presto/Dockerfile
@@ -1,30 +1,25 @@
 FROM centos:7.5.1804
 LABEL maintainer="https://www.starburstdata.com/"
 
-ARG presto_version=323-e.3
-ARG dist_location=""
+ARG presto_rpm
+ARG presto_cli
+ARG artifacts_dir="installdir"
 
 RUN yum -y install java-11-openjdk less && \
     yum clean all && \
     rm -rf /var/cache/yum && \
     echo OK
 
-COPY ./installdir /installdir
+COPY ./$artifacts_dir /$artifacts_dir
 
 RUN set -xeu && \
-    dist="$(/installdir/find-dist-location.sh "${dist_location}" "${presto_version}")" && \
-    yum -y localinstall "${dist}/presto-server-rpm-${presto_version}.x86_64.rpm" && \
+    yum -y install "/${artifacts_dir}/${presto_rpm}" && \
     rpm -qa | grep -q presto-server && \
-    cli_location="${dist}/presto-cli-${presto_version}-executable.jar" && \
-    if test -f "${cli_location}"; then \
-        cp -a "${cli_location}" /usr/local/bin/presto-cli; \
-    else \
-        curl -fsSL "${cli_location}" -o /usr/local/bin/presto-cli; \
-    fi && \
+    cp -a "/${artifacts_dir}/${presto_cli}" /usr/local/bin/presto-cli; \
     chmod -v +x /usr/local/bin/presto-cli && \
     ln -vs /usr/local/bin/presto-cli / `# backwards compatibility ` && \
     yum clean all && \
-    rm -vr /installdir && \
+    rm -vr /"${artifacts_dir}" && \
     echo OK
 
 COPY etc /usr/lib/presto/etc

--- a/presto/README.md
+++ b/presto/README.md
@@ -28,12 +28,14 @@ Presto cluster overview webpage is available at [localhost:8080](http://localhos
 
 ## Custom build
 
-To build a container using RPM and CLI that are not publicly downloadable from the Internet run:
+To build a container using RPM and CLI artifacts that are not publicly downloadable from the
+Internet download the RPM and CLI in the `installdir` directory. Both should have the following
+naming format in order to be recognized by the `build-image.sh` script:
+`presto-server-rpm-${PRESTO_VERSION}.x86_64.rpm` and
+`presto-cli-${PRESTO_VERSION}-executable.jar`.
+
 ```bash
-presto_rpm=<location of presto-server-rpm fil>
-presto_cli=<location of presto-cli executable jar>
-presto_version=<presto version>
-./build-image.sh --rpm "${presto_rpm}" --cli "${presto_cli}" --version "${presto_version}"
+./build-image.sh --version "${PRESTO-VERSION}"
 ```
 
 ## Custom build (incremetal) FOR DEVELOPMENT PURPOSES ONLY

--- a/presto/jenkins-release-image.sh
+++ b/presto/jenkins-release-image.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Gets the command name without path
+function cmd()
+{
+  basename $0
+}
+
+function usage()
+{
+  echo "\
+`cmd` [OPTIONS...]
+
+  This utility is used to build and push the starburstdata Presto and UBI
+  images.
+
+-p, --do-not-push  Flag preventing the newly built Docker image from being pushed
+                   to the Docker registry. This flag acts on both
+                   the Presto image and UBI. By default newly built images are
+                   pushed.
+
+-l, --latest       Flag indicating if the Presto image should be pushed to the
+                   latest tag. Defaults to false.
+
+-u, --ubi          Flag indiciating if the Universal Base Image of Presto should
+                   be built. Defaults to false.
+"
+}
+
+PUSH=true
+LATEST=false
+UBI=false
+# Edit this variable directly to build and release another version
+PRESTO_VERSION="323-e.3"
+
+options=$(getopt -o plu --long do-not-push,latest,ubi -n 'parse-options' -- "$@")
+
+if [ $? != 0 ]; then
+  echo "Failed parsing options." >&2
+  exit 1
+fi
+
+while true; do
+  case "$1" in
+    -p | --do-not-push) PUSH=false; shift ;;
+    -l | --latest) LATEST=true; shift ;;
+    -u | --ubi) UBI=true; shift ;;
+    -- ) shift; break ;;
+    "" ) break ;;
+    * ) echo "Unknown option provided ${1}"; usage; exit 1; ;;
+  esac
+done
+
+set -xeuo pipefail
+
+if [ "$PUSH" = true ] ; then
+    docker login --username $JENKINS_USERNAME --password $JENKINS_PASSWORD
+fi
+
+./build-image.sh --version $PRESTO_VERSION 
+
+if [ "$PUSH" = true ] ; then
+    docker push starburstdata/presto:$PRESTO_VERSION
+fi
+
+if [ "$LATEST" = true ] ; then
+  docker tag starburstdata/presto:$PRESTO_VERSION starburstdata/presto:latest
+  docker push starburstdata/presto:latest
+fi
+
+if [ "$UBI" = true ] ; then
+  virtualenv -p python3 .venv
+  source .venv/bin/activate
+  pip3 install awscli --upgrade
+  aws ecr get-login --no-include-email --region us-east-2 | bash
+  DOCKER_REGISTRY="200442618260.dkr.ecr.us-east-2.amazonaws.com/k8s"
+  docker build . -t $DOCKER_REGISTRY/starburstdata/presto:${TAG}-ubi8.1 --build-arg base_image="$DOCKER_REGISTRY/starburstdata/ubi8-python2:1"
+  docker push $DOCKER_REGISTRY/starburstdata/presto:${TAG}-ubi8.1
+fi


### PR DESCRIPTION
Move the artifact (RPM & CLI) download outside of the Presto Dockerfile.
Introduce a `jenkins-release-image.sh` script that can drive the build
and push of new containers. This will replace the inline script
currently used in the Jenkins job.

A pleasant side effect of this change is that the Presto RPM is no
longer left in the resulting container thus reducing the size of the
image from 3.43 GB to 2.41 GB.